### PR TITLE
Use correct script name for init script correcting the traceback output

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -146,8 +146,10 @@ module::module(
 		CTOR_FAIL(-1, "load init script");
 	
 	m_debug_proc = lua_pushtraceback(m_interp);
-	
-	int load_result = luaL_loadbuffer(m_interp, (const char*)linit.begin(), linit.size(), m_log_path.c_str());
+
+	// IMC - init file path corrected for traceback
+	std::string init_log_path = in_init_script + boiler_plate_paths;
+	int load_result = luaL_loadbuffer(m_interp, (const char*)linit.begin(), linit.size(), init_log_path.c_str());
 	CTOR_FAIL(load_result, "load init script")
 
 	int init_script_result = lua_pcall(m_interp, 0, 0, m_debug_proc);


### PR DESCRIPTION
The current code uses the module script name for the init script content resulting in a confusing debug.traceback content.

This patch uses the in_init_script to build the correct name for the script resulting in a traceback like this:

```
xlua: traceback: [string "init.lua"]:240: bad argument #2 to 'XLuaWrapCommand' (nil not allowed for callback)
stack traceback:
	[C]: at 0x7ff8291f5660
	[C]: in function 'XLuaWrapCommand'
	[string "init.lua"]:240: in function 'wrap_command'
	[string "scripts/C90_sys/C90_sys.lua"]:3958: in function 'fn'
	[string "init.lua"]:498: in function <[string "init.lua"]:474>
```
