### PR TITLE
Allow config file to disable the plugin menu creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Using "Developer > Reload the Current Aircraft and Art" X-Plane menu will reload
 
 Since 1.2.0, you can also reload your scripts via the aircraft menu, or via the `laminar/xlua/reload_all_scripts` command.
 
+If you don't need the menu item, you can create a file `config.ini` in `plugins/xlua/config.ini` and add the line:
+```ini
+show_plugin_menu=false
+```
+Which will not create the menu item. The command to reload your scripts is uneffected, which allows you to implement your own menu item.
+
 On some complex aircraft, you might also need to reset your scripts if the "Start with engines running" checkbox on the "Flight Configuration" screen changes. In this case, you can insert the `XLuaReloadOnFlightChange()` instruction once on any of your scripts, in any place. Note that this DOES NOT invoke an immediate reload of the scripts, but only flags the aircraft scripts to be reloaded when the flight configuration changes, which is something that XLua didn't do before.
 
 ### FAQ

--- a/src/xlua.cpp
+++ b/src/xlua.cpp
@@ -18,6 +18,8 @@
 #define XPLM210
 #endif
 
+#include <algorithm>
+#include <fstream>
 #include <XPLMPlugin.h>
 #include <XPLMDataAccess.h>
 #include <XPLMUtilities.h>
@@ -25,6 +27,7 @@
 #include <XPLMMenus.h>
 #include <XPLMPlanes.h>
 
+#include "log.h"
 #include "module.h"
 #include "xpdatarefs.h"
 #include "xpcommands.h"
@@ -252,6 +255,61 @@ static void MenuHandler(void* menuRef, void* itemRef)
 	}
 }
 
+static vector<string> load_file(const string& path)
+{
+	std::ifstream f(path.c_str());
+
+	if (!f.is_open())
+	{
+		log_message(nullptr, "Could not open file %s.\n", path.c_str());
+		return {};
+	}
+
+	vector<string> result;
+	string line;
+
+	while (getline(f, line))
+	{
+		result.push_back(line);
+	}
+
+	return result;
+}
+
+static std::string trim(std::string s) {
+	auto notspace = [](int ch) { return !std::isspace(ch); };
+	s.erase(s.begin(), std::find_if(s.begin(), s.end(), notspace));
+	s.erase(std::find_if(s.rbegin(), s.rend(), notspace).base(), s.end());
+	return s;
+}
+
+
+static bool GetShowMenuConfig(const string& path)
+{
+	vector<string> config = load_file(path);
+	if (config.empty())
+		return true;
+
+	for (auto config_line : config)
+	{
+		const string::size_type pos = config_line.find("show_plugin_menu");
+		if (pos == string::npos)
+			return true;
+
+		const string::size_type eq = config_line.find('=', pos);
+		if (eq == string::npos)
+			return true;
+
+		const string val = trim(config_line.substr(eq + 1));
+		if (val == "false" || val == "0")
+			return false;
+
+		return true;
+	}
+
+	return true;
+}
+
 PLUGIN_API int XPluginStart(
 						char *		outName,
 						char *		outSig,
@@ -294,10 +352,13 @@ PLUGIN_API int XPluginStart(
 	}
 	plugin_base_path += XPLMGetDirectorySeparator();
 
+	const string configPath = plugin_base_path + "config.ini";
+	const bool addMenu = GetShowMenuConfig(configPath);
+
 	// Do we want to add a "reset" menu item? Only for the user's plane.
 	XPLMGetNthAircraftModel(XPLM_USER_AIRCRAFT, pName, pPath);
 	char *PDest = strrchr(pPath, *XPLMGetDirectorySeparator());
-	if (PDest != nullptr)
+	if (PDest != nullptr && addMenu)
 	{
 		*PDest = 0;
 		const size_t acPathLen = strlen(pPath);


### PR DESCRIPTION
We want to disable the automatic generation of the plugin menu entry with the option to reload all Lua scripts. We intend to have one plugin menu entry for our plane, and if required, we can quickly add an item there to allow the same functionality via the provided command.

Unfortunately, I didn't find an option to disable the creation, so I opened this PR with the option for a config file that allows disabling this behavior.